### PR TITLE
[rpm] Fix wrong permissions for initfs.tar.bz2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: initfs.tar.bz2
 install: all
 	install -d $(DESTDIR)$(PREFIX)/sbin/
 	install -m 755 initfs/scripts/*.sh $(DESTDIR)$(PREFIX)/sbin/
-	install -D initfs.tar.bz2 $(DESTDIR)$(PREFIX)/share/hw-ramdisk/initfs.tar.bz2
+	install -m 644 -D initfs.tar.bz2 $(DESTDIR)$(PREFIX)/share/hw-ramdisk/initfs.tar.bz2
 
 clean: tools_clean
 	rm -f initfs.tar.bz2


### PR DESCRIPTION
rpmlint found executable permissions for initfs.tar.bz2. Fixed by
explicitly setting the permissions to 644 when installing.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
