### PR TITLE
[rpm] Fix missing dependency to busybox-static

### DIFF
--- a/rpm/hw-ramdisk.spec
+++ b/rpm/hw-ramdisk.spec
@@ -9,7 +9,7 @@ Source0:    %{name}-%{version}.tar.gz
 BuildRequires:  findutils
 BuildRequires:  gzip
 BuildRequires:  cpio
-BuildRequires:  busybox-static
+Requires:  busybox-static
 
 
 %description


### PR DESCRIPTION
Busybox is not used during build time of the new hw-ramdisk tools,
but rather when the tools are run in target environment. So
make the dependency to busybox-static a run-time Requires.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
