### PR TITLE
[moslo] Add /sbin to PATH in moslo-build.sh. Fixes JB#29418

### DIFF
--- a/initfs/scripts/moslo-build.sh
+++ b/initfs/scripts/moslo-build.sh
@@ -245,6 +245,9 @@ echo
         exit 1
 }
 
+# Make sure sbin is in path in the build env.
+export PATH="/sbin:$PATH"
+
 #
 # check and cleanup
 #


### PR DESCRIPTION
When building in OBS, seems sbin is not in PATH so ldconfig fails
to run. Add /sbin to PATH to fix this.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>