### PR TITLE
[moslo] Don't overwrite existing tools with busybox links. Fixes NEMO#840

### DIFF
--- a/initfs/scripts/moslo-build.sh
+++ b/initfs/scripts/moslo-build.sh
@@ -341,9 +341,16 @@ rm -f $TMPFILE
 # Create (and fix) busybox links
 BUSYBOX_BINARY=`find $ROOT_DIR -name "busybox*"`
 echo "$BUSYBOX_BINARY"
-${BUSYBOX_BINARY} --install -s $ROOT_DIR/bin/
+BUSYBOX_TMP=$(mktemp -d -p $ROOT_DIR)
+mkdir -p $BUSYBOX_TMP/bin
+
+${BUSYBOX_BINARY} --install -s $BUSYBOX_TMP/bin/
+rsync -l --ignore-existing $BUSYBOX_TMP/bin/* $ROOT_DIR/bin/
+rm -rf $BUSYBOX_TMP
 for l in $ROOT_DIR/bin/*; do
-  ln -sf /sbin/busybox-static $l
+  if test -h $l; then
+    ln -sf /sbin/busybox-static $l
+  fi
 done
 
 #

--- a/rpm/hw-ramdisk.spec
+++ b/rpm/hw-ramdisk.spec
@@ -10,6 +10,7 @@ BuildRequires:  findutils
 BuildRequires:  gzip
 BuildRequires:  cpio
 Requires:  busybox-static
+Requires:  rsync
 
 
 %description


### PR DESCRIPTION
If you need to replace any of standard busybox tools with stand-alone
version, you can't do that currently as we overwrite everything by
installing busybox links after user defined tools have been installed.

Changed the busybox tool links installation to only add missing tools
and to update only symbolic links. rsync had to be used as cp is too
old and is missing option for skipping existing files.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
